### PR TITLE
I509

### DIFF
--- a/patchwork/templates/patchwork/series-detail.html
+++ b/patchwork/templates/patchwork/series-detail.html
@@ -1,0 +1,41 @@
+{% extends "base.html" %}
+
+{% load humanize %}
+{% load syntax %}
+{% load person %}
+{% load patch %}
+{% load static %}
+{% load utils %}
+
+{% block title %}{{series.name}}{% endblock %}
+
+{% block body %}
+
+<div>
+  <h1>{{ series.name }}</h1>
+</div>
+
+<table class="patch-meta">
+    <tr>
+        <th>Cover Letter</th>
+        <td>{{ series.cover_letter.content|default:"No cover letter available" }}</td>
+    </tr>
+    <tr>
+        <th>Date</th>
+        <td>{{ series.date }}</td>
+    </tr>
+    <tr>
+        <th>Submitter</th>
+        <td>{{ series.submitter }}</td>
+    </tr>
+    <tr>
+        <th>Total</th>
+        <td>{{ series.patches }}</td>
+    </tr>
+</table>
+<br>
+<h2>Patches:</h2>
+<br>
+{% include "patchwork/partials/patch-list.html" %}
+
+{% endblock %}

--- a/patchwork/templates/patchwork/series-list.html
+++ b/patchwork/templates/patchwork/series-list.html
@@ -1,0 +1,99 @@
+{% extends "base.html" %}
+
+{% load person %}
+{% load static %}
+
+{% block title %}{{project.name}}{% endblock %}
+{% block series_active %}active{% endblock %}
+
+{% block body %}
+
+{% load person %}
+{% load listurl %}
+{% load patch %}
+{% load project %}
+{% load static %}
+
+{% include "patchwork/partials/pagination.html" %}
+
+<input type="hidden" name="form" value="serieslistform"/>
+<input type="hidden" name="project" value="{{project.id}}"/>
+
+<table id="serieslist" class="table table-hover table-extra-condensed table-striped pw-list" data-toggle="checkboxes" data-range="true">
+  <thead>
+    <tr>
+{% if user.is_authenticated and user.profile.show_ids %}
+      <th>
+        ID
+      </th>
+{% endif %}
+
+      <th>
+        Version
+      </th>
+
+      <th>
+        <span class="colinactive">Series</span>
+      </th>
+
+      <th>
+        <span class="colinactive">Cover Letter</span>
+      </th>
+
+      <th>
+        <span class="colinactive">Number of Patches</span>
+      </th>
+
+      <th>
+        <span class="colinactive">Date</span>
+      </th>
+
+      <th>
+        <span class="colinactive">Submitter</span>
+      </th>
+
+      <th>
+        <span class="colinactive"> Edit patches </span>
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+{% for series in series_list %}
+    <tr id="series_row:{{series.id}}">
+{% if user.is_authenticated and user.profile.show_ids %}
+      <td>
+        <button type="button" class="btn btn-xs btn-copy" data-clipboard-text="{{ series.id }}" title="Copy to Clipboard">
+          {{ series.id }}
+        </button>
+      </td>
+{% endif %}
+      <td>
+        {{ series.version|default:"-"}}
+      </td>
+      <td>
+        <a href="{% url 'series-detail' series_id=series.id %}">
+          {{ series.name|default:"[no subject]"|truncatechars:100 }}
+        </a>
+      </td>
+      <td>{{ series.cover_letter.content|default:"No cover letter available" }}</td>
+      <td>{{ series.received_total}}</td>
+      <td class="text-nowrap">{{ series.date|date:"Y-m-d" }}</td>
+      <td>{{ series.submitter|personify:project }}</td>
+      <td>
+        <form method="post">
+            {% csrf_token %}
+            {{ form.as_p }}
+            <button type='submit' name="save" value="{{ series.id }}">Save</button>
+        </form>
+      </td>
+    </tr>
+{% empty %}
+    <tr>
+      <td colspan="8">No series to display</td>
+    </tr>
+{% endfor %}
+  </tbody>
+</table>
+
+{% endblock %}

--- a/patchwork/templates/patchwork/submission.html
+++ b/patchwork/templates/patchwork/submission.html
@@ -20,6 +20,22 @@
   <h1>{{ submission.name }}</h1>
 </div>
 
+<div class="btn-group pull-right">
+  <a class="btn btn-default {% if not next_submission %} disabled {% endif %}"
+  {% if next_submission %} href="{% url 'patch-detail' project_id=project.linkname msgid=next_submission.encoded_msgid %}" {% endif %}>
+    next
+  </a>
+</div>
+
+<div class="btn-group pull-right">
+  <a
+    class="btn btn-default {% if not previous_submission %} disabled {% endif %}"
+    {% if previous_submission %} href="{% url 'patch-detail' project_id=project.linkname msgid=previous_submission.encoded_msgid %}" {% endif %}
+  >
+    previous
+  </a>
+</div>
+
 <table id="patch-meta" class="patch-meta" data-submission-type={{submission|verbose_name_plural|lower}} data-submission-id={{submission.id}}>
   <tr>
     <th>Message ID</th>

--- a/patchwork/tests/views/test_series.py
+++ b/patchwork/tests/views/test_series.py
@@ -1,0 +1,84 @@
+# Patchwork - automated patch tracking system
+# Copyright (C) 2012 Jeremy Kerr <jk@ozlabs.org>
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+from datetime import datetime as dt
+
+from django.test import TestCase
+from django.urls import reverse
+
+from patchwork.models import Patch
+from patchwork.models import Person
+from patchwork.tests.utils import create_patch
+from patchwork.tests.utils import create_cover
+from patchwork.tests.utils import create_person
+from patchwork.tests.utils import create_project
+from patchwork.tests.utils import create_series
+from patchwork.tests.utils import create_user
+
+
+class SeriesList(TestCase):
+    def setUp(self):
+        self.project = create_project()
+        self.user = create_user()
+        self.person_1 = Person.objects.get(user=self.user)
+        self.person_2 = create_person()
+        self.series_1 = create_series(project=self.project)
+        self.series_2 = create_series(project=self.project)
+        create_cover(project=self.project, series=self.series_1)
+
+        for i in range(5):
+            create_patch(
+                submitter=self.person_1,
+                project=self.project,
+                series=self.series_1,
+                date=dt(2014, 3, 16, 13, 4, 50, 155643),
+            )
+            create_patch(
+                submitter=self.person_2,
+                project=self.project,
+                series=self.series_2,
+                date=dt(2014, 3, 16, 13, 4, 50, 155643),
+            )
+
+        # with open('output.html', "w", encoding="utf-8") as file:
+        #     file.write(response.content.decode('utf-8'))
+
+    def test_series_list(self):
+        requested_url = reverse(
+            'series-list',
+            kwargs={'project_id': self.project.linkname},
+        )
+        response = self.client.get(requested_url)
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_update_series_list_unauth(self):
+        requested_url = reverse(
+            'series-list',
+            kwargs={'project_id': self.project.linkname},
+        )
+
+        data = {'save': self.series_1.id, 'archived': 'True', 'state': '*'}
+        response = self.client.post(requested_url, data)
+
+        self.assertContains(
+            response, 'You don&#x27;t have permissions to edit patch'
+        )
+
+    def test_update_series_list(self):
+        requested_url = reverse(
+            'series-list',
+            kwargs={'project_id': self.project.linkname},
+        )
+
+        data = {'save': self.series_1.id, 'archived': 'True', 'state': '*'}
+        self.client.login(
+            username=self.user.username, password=self.user.username
+        )
+        _ = self.client.post(requested_url, data)
+
+        patches = Patch.objects.filter(series=self.series_1)
+        for patch in patches:
+            self.assertEqual(patch.archived, True)

--- a/patchwork/urls.py
+++ b/patchwork/urls.py
@@ -116,6 +116,11 @@ urlpatterns = [
     ),
     # series views
     path(
+        'series/<int:series_id>/',
+        series_views.series_detail,
+        name='series-detail',
+    ),
+    path(
         'series/<int:series_id>/mbox/',
         series_views.series_mbox,
         name='series-mbox',

--- a/patchwork/urls.py
+++ b/patchwork/urls.py
@@ -37,6 +37,11 @@ urlpatterns = [
         name='patch-list',
     ),
     path(
+        'project/<project_id>/series-list/',
+        series_views.series_list,
+        name='series-list',
+    ),
+    path(
         'project/<project_id>/bundles/',
         bundle_views.bundle_list,
         name='bundle-list',

--- a/patchwork/views/patch.py
+++ b/patchwork/views/patch.py
@@ -148,6 +148,20 @@ def patch_detail(request, project_id, msgid):
     context['related_same_project'] = related_same_project
     context['related_different_project'] = related_different_project
 
+    try:
+        context['previous_submission'] = Patch.objects.get(
+            series=patch.series, number=patch.number - 1
+        )
+    except Patch.DoesNotExist:
+        context['previous_submission'] = None
+
+    try:
+        context['next_submission'] = Patch.objects.get(
+            series=patch.series, number=patch.number + 1
+        )
+    except Patch.DoesNotExist:
+        context['next_submission'] = None
+
     return render(request, 'patchwork/submission.html', context)
 
 

--- a/patchwork/views/series.py
+++ b/patchwork/views/series.py
@@ -8,7 +8,9 @@ from django.shortcuts import get_object_or_404
 from django.shortcuts import render
 
 from patchwork.models import Series
+from patchwork.models import Patch
 from patchwork.models import Project
+from patchwork.views import generic_list
 from patchwork.views.utils import series_to_mbox
 from patchwork.forms import SeriesBulkUpdatePatchesForm
 
@@ -23,6 +25,24 @@ def series_mbox(request, series_id):
     )
 
     return response
+
+
+def series_detail(request, series_id):
+    series = get_object_or_404(Series, id=series_id)
+
+    patches = Patch.objects.filter(series=series)
+
+    context = generic_list(
+        request,
+        series.project,
+        'series-detail',
+        view_args={'series_id': series_id},
+        patches=patches,
+    )
+
+    context.update({'series': series})
+
+    return render(request, 'patchwork/series-detail.html', context)
 
 
 def series_list(request, project_id):

--- a/releasenotes/notes/add_series_list_view-bf219022216fea6a.yaml
+++ b/releasenotes/notes/add_series_list_view-bf219022216fea6a.yaml
@@ -1,0 +1,13 @@
+---
+prelude: >
+    Some projects can have hundreds of patches actives at once, by giving the user
+    the ability to have an overview of all of the series makes knowing what's the
+    current state of a project much more simple.
+features:
+  - |
+    Add SeriesBulkUpdatePatchesForm, a form that allows changing the state of all of
+    the patches contained in a series at once.
+    Add series-list view, a view containing all of the series for a project and that also
+    implements the SeriesBulkUpdatePatchesForm, allowing the user to edit all of the patches
+    within a series using the web ui.
+    Add series-detail view, a view containing details about a series and all of it's patches

--- a/templates/base.html
+++ b/templates/base.html
@@ -48,6 +48,12 @@
 {% block navbarmenu %}
 {% if project %}
           <ul class="nav navbar-nav">
+            <li class="{% block series_active %}{% endblock %}">
+              <a href="{% url 'series-list' project_id=project.linkname %}">
+                <span class="glyphicon glyphicon-file"></span>
+                Series
+              </a>
+            </li>
             <li class="{% block patch_active %}{% endblock %}">
               <a href="{% url 'patch-list' project_id=project.linkname %}">
                 <span class="glyphicon glyphicon-file"></span>


### PR DESCRIPTION
### Description

This PR adds a new `series-list` view.
Some projects can have hundreds of patches actives at once, by giving the user the ability to have an overview of all of the series makes knowing what's the current state of a project much more simple.
This view also allows the user to apply changes to all of the patches of a determined series, making the management of them easier

### Related

- Closes #509